### PR TITLE
Bump versions of dependencies in templates

### DIFF
--- a/working/templates/dotnetToolProject/$ProjectName$.csproj
+++ b/working/templates/dotnetToolProject/$ProjectName$.csproj
@@ -32,10 +32,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Serilog" Version="4.0.0" />
-    <PackageReference Include="Serilog.Extensions.Logging" Version="8.0.0" />
+    <PackageReference Include="Serilog" Version="4.2.0" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="9.0.1" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
-    <PackageReference Include="Skyline.DataMiner.CICD.FileSystem" Version="1.1.0" />
+    <PackageReference Include="Skyline.DataMiner.CICD.FileSystem" Version="1.3.0" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
   </ItemGroup>
 </Project>

--- a/working/templates/dotnetToolSolution/ClassLibrary1/ClassLibrary1.csproj
+++ b/working/templates/dotnetToolSolution/ClassLibrary1/ClassLibrary1.csproj
@@ -32,10 +32,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Serilog" Version="4.0.0" />
-    <PackageReference Include="Serilog.Extensions.Logging" Version="8.0.0" />
+    <PackageReference Include="Serilog" Version="4.2.0" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="9.0.1" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
-    <PackageReference Include="Skyline.DataMiner.CICD.FileSystem" Version="1.1.0" />
+    <PackageReference Include="Skyline.DataMiner.CICD.FileSystem" Version="1.3.0" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
   </ItemGroup>
 </Project>

--- a/working/templates/dxmsolution/NuGetProject/NuGetProject.csproj
+++ b/working/templates/dxmsolution/NuGetProject/NuGetProject.csproj
@@ -29,7 +29,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Skyline.DataMiner.Utils.SecureCoding.Analyzers" Version="1.2.3">
+    <PackageReference Include="Skyline.DataMiner.Utils.SecureCoding.Analyzers" Version="2.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/working/templates/dxmsolution/ServiceProject/ServiceProject.csproj
+++ b/working/templates/dxmsolution/ServiceProject/ServiceProject.csproj
@@ -11,9 +11,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="8.0.0"/>
-    <PackageReference Include="Skyline.DataMiner.CICD.FileSystem" Version="1.1.0"/>
-    <PackageReference Include="Skyline.DataMiner.Utils.SecureCoding.Analyzers" Version="1.2.3">
+    <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="9.0.4"/>
+    <PackageReference Include="Skyline.DataMiner.CICD.FileSystem" Version="1.3.0"/>
+    <PackageReference Include="Skyline.DataMiner.Utils.SecureCoding.Analyzers" Version="2.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/working/templates/nugetProject/$ProjectName$.csproj
+++ b/working/templates/nugetProject/$ProjectName$.csproj
@@ -29,7 +29,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Skyline.DataMiner.Utils.SecureCoding.Analyzers" Version="1.2.3">
+    <PackageReference Include="Skyline.DataMiner.Utils.SecureCoding.Analyzers" Version="2.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/working/templates/nugetsolution/ClassLibrary1/ClassLibrary1.csproj
+++ b/working/templates/nugetsolution/ClassLibrary1/ClassLibrary1.csproj
@@ -29,7 +29,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Skyline.DataMiner.Utils.SecureCoding.Analyzers" Version="1.2.3">
+    <PackageReference Include="Skyline.DataMiner.Utils.SecureCoding.Analyzers" Version="2.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
- Skyline.DataMiner.Utils.SecureCoding.Analyzers: from 1.2.3 to 2.0.1
- Skyline.DataMiner.CICD.FileSystem: from 1.1.0 to 1.3.0
- Microsoft.Extensions.HostingWindowsServices: from 8.0.0 to 9.0.4
- Serilog: from 4.0.0 to 4.2.0
- Serilog.Extensions.Logging: from 8.0.0 to 9.0.1