### PR TITLE
Bump versions + small change in .NET tool

### DIFF
--- a/working/templates/dotnetToolProject/$ProjectName$.csproj
+++ b/working/templates/dotnetToolProject/$ProjectName$.csproj
@@ -32,17 +32,16 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.6" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.9" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="9.0.2" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
-    <PackageReference Include="Skyline.DataMiner.CICD.FileSystem" Version="1.3.0" />
+    <PackageReference Include="Skyline.DataMiner.CICD.FileSystem" Version="1.4.0" />
     <PackageReference Include="System.CommandLine.Hosting" Version="0.4.0-alpha.22272.1" />
   </ItemGroup>
 
   <ItemGroup>
     <Using Include="Microsoft.Extensions.Configuration" />
     <Using Include="Microsoft.Extensions.Logging" />
-    <Using Include="Skyline.DataMiner.CICD.FileSystem" />
     <Using Include="Skyline.DataMiner.CICD.FileSystem.DirectoryInfoWrapper" />
     <Using Include="Skyline.DataMiner.CICD.FileSystem.DirectoryInfoWrapper.DirectoryInfo">
       <Alias>DirectoryInfo</Alias>

--- a/working/templates/dotnetToolProject/SystemCommandLine/OptionExtensions.cs
+++ b/working/templates/dotnetToolProject/SystemCommandLine/OptionExtensions.cs
@@ -1,6 +1,8 @@
 ﻿// ReSharper disable UnusedMember.Global
 namespace $PackageId$.SystemCommandLine
 {
+    using Skyline.DataMiner.CICD.FileSystem;
+
     internal static class OptionExtensions
     {
         /// <summary>

--- a/working/templates/dotnetToolProject/SystemCommandLine/OptionHelper.cs
+++ b/working/templates/dotnetToolProject/SystemCommandLine/OptionHelper.cs
@@ -1,6 +1,8 @@
 ﻿// ReSharper disable UnusedMember.Global
 namespace $PackageId$.SystemCommandLine
 {
+    using Skyline.DataMiner.CICD.FileSystem;
+
     /// <summary>
     /// Helper methods so that System.CommandLine can deal with CICD.FileSystem classes.
     /// </summary>
@@ -37,7 +39,7 @@ namespace $PackageId$.SystemCommandLine
             }
 
             string tokenValue = result.Tokens[0].Value;
-            if (CICD.FileSystem.FileSystem.Instance.File.GetAttributes(tokenValue).HasFlag(System.IO.FileAttributes.Directory))
+            if (FileSystem.Instance.File.GetAttributes(tokenValue).HasFlag(System.IO.FileAttributes.Directory))
             {
                 return new DirectoryInfo(tokenValue);
             }

--- a/working/templates/dotnetToolSolution/ClassLibrary1/ClassLibrary1.csproj
+++ b/working/templates/dotnetToolSolution/ClassLibrary1/ClassLibrary1.csproj
@@ -32,17 +32,16 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.6" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.9" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="9.0.2" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
-    <PackageReference Include="Skyline.DataMiner.CICD.FileSystem" Version="1.3.0" />
+    <PackageReference Include="Skyline.DataMiner.CICD.FileSystem" Version="1.4.0" />
     <PackageReference Include="System.CommandLine.Hosting" Version="0.4.0-alpha.22272.1" />
   </ItemGroup>
 
   <ItemGroup>
     <Using Include="Microsoft.Extensions.Configuration" />
     <Using Include="Microsoft.Extensions.Logging" />
-    <Using Include="Skyline.DataMiner.CICD.FileSystem" />
     <Using Include="Skyline.DataMiner.CICD.FileSystem.DirectoryInfoWrapper" />
     <Using Include="Skyline.DataMiner.CICD.FileSystem.DirectoryInfoWrapper.DirectoryInfo">
       <Alias>DirectoryInfo</Alias>

--- a/working/templates/dotnetToolSolution/ClassLibrary1/SystemCommandLine/OptionExtensions.cs
+++ b/working/templates/dotnetToolSolution/ClassLibrary1/SystemCommandLine/OptionExtensions.cs
@@ -1,6 +1,8 @@
 ﻿// ReSharper disable UnusedMember.Global
 namespace $PackageId$.SystemCommandLine
 {
+    using Skyline.DataMiner.CICD.FileSystem;
+
     internal static class OptionExtensions
     {
         /// <summary>

--- a/working/templates/dotnetToolSolution/ClassLibrary1/SystemCommandLine/OptionHelper.cs
+++ b/working/templates/dotnetToolSolution/ClassLibrary1/SystemCommandLine/OptionHelper.cs
@@ -1,6 +1,8 @@
 ﻿// ReSharper disable UnusedMember.Global
 namespace $PackageId$.SystemCommandLine
 {
+    using Skyline.DataMiner.CICD.FileSystem;
+
     /// <summary>
     /// Helper methods so that System.CommandLine can deal with CICD.FileSystem classes.
     /// </summary>
@@ -37,7 +39,7 @@ namespace $PackageId$.SystemCommandLine
             }
 
             string tokenValue = result.Tokens[0].Value;
-            if (CICD.FileSystem.FileSystem.Instance.File.GetAttributes(tokenValue).HasFlag(System.IO.FileAttributes.Directory))
+            if (FileSystem.Instance.File.GetAttributes(tokenValue).HasFlag(System.IO.FileAttributes.Directory))
             {
                 return new DirectoryInfo(tokenValue);
             }

--- a/working/templates/dxmsolution/NuGetProject/NuGetProject.csproj
+++ b/working/templates/dxmsolution/NuGetProject/NuGetProject.csproj
@@ -29,7 +29,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Skyline.DataMiner.Utils.SecureCoding.Analyzers" Version="2.0.5">
+    <PackageReference Include="Skyline.DataMiner.Utils.SecureCoding.Analyzers" Version="2.2.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/working/templates/dxmsolution/ServiceProject/ServiceProject.csproj
+++ b/working/templates/dxmsolution/ServiceProject/ServiceProject.csproj
@@ -11,9 +11,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="9.0.6"/>
-    <PackageReference Include="Skyline.DataMiner.CICD.FileSystem" Version="1.3.0"/>
-    <PackageReference Include="Skyline.DataMiner.Utils.SecureCoding.Analyzers" Version="2.0.5">
+    <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="9.0.9"/>
+    <PackageReference Include="Skyline.DataMiner.CICD.FileSystem" Version="1.4.0"/>
+    <PackageReference Include="Skyline.DataMiner.Utils.SecureCoding.Analyzers" Version="2.2.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/working/templates/nugetProject/$ProjectName$.csproj
+++ b/working/templates/nugetProject/$ProjectName$.csproj
@@ -29,7 +29,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Skyline.DataMiner.Utils.SecureCoding.Analyzers" Version="2.0.5">
+    <PackageReference Include="Skyline.DataMiner.Utils.SecureCoding.Analyzers" Version="2.2.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/working/templates/nugetsolution/ClassLibrary1/ClassLibrary1.csproj
+++ b/working/templates/nugetsolution/ClassLibrary1/ClassLibrary1.csproj
@@ -29,7 +29,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Skyline.DataMiner.Utils.SecureCoding.Analyzers" Version="2.0.5">
+    <PackageReference Include="Skyline.DataMiner.Utils.SecureCoding.Analyzers" Version="2.2.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
This pull request updates several project templates to use newer versions of key NuGet packages and makes minor improvements to code that integrates with the `Skyline.DataMiner.CICD.FileSystem` library. The changes primarily focus on dependency upgrades for better compatibility and security, as well as some minor code cleanups to improve maintainability.

Dependency upgrades:

* Upgraded `Microsoft.Extensions.Hosting` and `Microsoft.Extensions.Hosting.WindowsServices` from version 9.0.6 to 9.0.9 in relevant `.csproj` files.
* Updated `Skyline.DataMiner.CICD.FileSystem` from version 1.3.0 to 1.4.0 in affected projects.
* Bumped `Skyline.DataMiner.Utils.SecureCoding.Analyzers` from version 2.0.5 to 2.2.1 across multiple templates.

Code improvements and cleanup:

* Added explicit `using Skyline.DataMiner.CICD.FileSystem;` statements in `OptionExtensions.cs` and `OptionHelper.cs` to clarify dependencies.
* Simplified access to the `FileSystem` instance in `OptionHelper.cs` by removing the redundant namespace qualifier.