### PR TITLE
Remove commented formatting instructions in manifest.yml

### DIFF
--- a/working/templates/SharedItems/CatalogInformation/manifest.yml
+++ b/working/templates/SharedItems/CatalogInformation/manifest.yml
@@ -56,7 +56,6 @@ documentation_url:
 
 # [Optional]
 # People who are responsible for this Catalog item. Might be developers, but this is not required.
-# Format: 'name <email> (url)'
 #   The name is required; max 256 characters.
 #   The email and url are optional, and should be in valid email/URL formats.
 owners:
@@ -71,7 +70,6 @@ owners:
 #   Cannot contain newlines.
 #   Cannot contain leading or trailing whitespace characters.
 tags:
-  - 
   - 
 
 # [Optional]


### PR DESCRIPTION
Synced with what is documented on Docs (https://docs.dataminer.services/dataminer/dataminer_services/Catalog/Register_Catalog_Item.html)