### PR TITLE
Remove SonarCloud requirement from master workflow

### DIFF
--- a/working/templates/SharedItems/.github/workflows/complete.yml
+++ b/working/templates/SharedItems/.github/workflows/complete.yml
@@ -19,10 +19,6 @@ on:
 jobs:
 
   CI:
+    # For more information which inputs and secrets are available, see the documentation of the reusable workflow:
+    # https://docs.dataminer.services/develop/CICD/GitHub/GitHubReusableWorkflows/GitHub_Reusable_Workflows_Master_Workflow.html
     uses: SkylineCommunications/_ReusableWorkflows/.github/workflows/Master Workflow.yml@main
-    with:
-      sonarcloud-project-name: ${{ vars.SONAR_NAME }} # Go to 'https://sonarcloud.io/projects/create' and create a project. Then create a SONAR_NAME variable with the ID of the project as mentioned in the SonarCloud project URL.
-      # solution-filter-name: "MySolutionFilter.slnf"
-    # secrets:
-      # DATAMINER_TOKEN: ${{ secrets.DATAMINER_TOKEN }} # The API key: generated in the DCP Admin app (https://admin.dataminer.services/) as authentication for a certain organization.
-      # OVERRIDE_CATALOG_DOWNLOAD_TOKEN: ${{ secrets.OVERRIDE_DATAMINER_TOKEN }} # Override on the dataminerToken for downloading Catalog items: generated in the DCP Admin app (https://admin.dataminer.services/) as authentication for a certain organization.


### PR DESCRIPTION
This pull request updates the `complete.yml` workflow configuration to simplify and clarify its usage. The main change is the removal of inline input and secret parameters, with added documentation pointing users to the official reusable workflow documentation for details.

Workflow configuration simplification:

* Removed explicit `with` and commented-out `secrets` parameters, reducing clutter and potential confusion in the `CI` job configuration in `complete.yml`.
* Added a comment with a documentation link to guide users on available inputs and secrets for the reusable workflow.