### PR TITLE
DxM Solution - Adapt to be GitHub workflow ready

### DIFF
--- a/working/templates/dxmsolution/InstallerProject/DxmModuleName.wxi
+++ b/working/templates/dxmsolution/InstallerProject/DxmModuleName.wxi
@@ -4,7 +4,7 @@
 
 			<Component Id="$DxmModuleName$ExeComponent" Guid="{942D1BB9-3A1A-4767-B53B-4076E4D0DB5B}" SharedDllRefCount="no" KeyPath="no" NeverOverwrite="no" Permanent="no" Transitive="no" Location="either" Bitness="always64">
 
-				<File Id="$FullDxmName$.exe" Name="$FullDxmName$.exe" Source="$(SolutionDir)$ServiceName$/bin/$(Configuration)/net10.0/$FullDxmName$.exe" ReadOnly="no" KeyPath="yes" Vital="yes" Hidden="no" System="no" Checksum="no" />
+				<File Id="$FullDxmName$.exe" Name="$FullDxmName$.exe" Source="$(MSBuildProjectDirectory)/../$ServiceName$/bin/$(Configuration)/net10.0/$FullDxmName$.exe" ReadOnly="no" KeyPath="yes" Vital="yes" Hidden="no" System="no" Checksum="no" />
 				
 				<ServiceInstall Id="$DxmModuleName$Install" DisplayName="$FullDxmName$" Name="$FullDxmName$" ErrorControl="normal" Start="auto" Type="ownProcess" Vital="yes">
 					<util:ServiceConfig RestartServiceDelayInSeconds="60" ResetPeriodInDays="1" FirstFailureActionType="restart" SecondFailureActionType="restart" ThirdFailureActionType="restart" />

--- a/working/templates/dxmsolution/InstallerProject/InstallerProject.wixproj
+++ b/working/templates/dxmsolution/InstallerProject/InstallerProject.wixproj
@@ -1,16 +1,16 @@
 ﻿<Project Sdk="WixToolset.Sdk/4.0.6">
-	<Import Project="Sdk.props" Sdk="WixToolset.Sdk" Version="4.0.6"/>
 	<PropertyGroup>
 		<ProductVersion>1.0.0.0</ProductVersion>
 		<Name>$InstallerName$</Name>
+		<InstallerPlatform>x64</InstallerPlatform>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
-		<DefineConstants>Debug;ProductVersion=$(ProductVersion)</DefineConstants>
+		<DefineConstants>$(DefineConstants);Debug;ProductVersion=$(ProductVersion);MSBuildProjectDirectory=$(MSBuildProjectDirectory)</DefineConstants>
 		<WixVariables>ProductVersion=$(ProductVersion)</WixVariables>
 		<OutputName>$FullDxmName$ $(ProductVersion) ($(Configuration))</OutputName>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
-		<DefineConstants>ProductVersion=$(ProductVersion)</DefineConstants>
+		<DefineConstants>$(DefineConstants);ProductVersion=$(ProductVersion);MSBuildProjectDirectory=$(MSBuildProjectDirectory)</DefineConstants>
 		<WixVariables>ProductVersion=$(ProductVersion)</WixVariables>
 		<OutputName>$FullDxmName$ $(ProductVersion)</OutputName>
 		<SuppressPdbOutput>true</SuppressPdbOutput>
@@ -49,7 +49,7 @@
 	<Import Project="Sdk.targets" Sdk="WixToolset.Sdk" Version="4.0.6"/>
 	<Target Name="BeforeBuild">
 		<!-- Optional publishing of webApp you actually want to install.-->
-		<!--<Exec Command="dotnet publish $(SolutionDir)Path\To\My\app.csproj -c $(Configuration) -p:PublishProfile=$(Configuration)" />-->
+		<!--<Exec Command="dotnet publish $(MSBuildProjectDirectory)\..\Path\To\My\app.csproj -c $(Configuration) -p:PublishProfile=$(Configuration)" />-->
 		<PropertyGroup>
 			<HarvestDirectoryAutogenerateGuids>true</HarvestDirectoryAutogenerateGuids>
 			<HarvestDirectorySuppressFragments>true</HarvestDirectorySuppressFragments>
@@ -57,7 +57,7 @@
 			<HarvestDirectorySuppressUniqueIds>false</HarvestDirectorySuppressUniqueIds>
 		</PropertyGroup>
 		<ItemGroup>
-			<HarvestDirectory Include="$(SolutionDir)$ServiceName$/bin/$(Configuration)/net10.0">
+			<HarvestDirectory Include="$(MSBuildProjectDirectory)/../$ServiceName$/bin/$(Configuration)/net10.0">
 				<!--<PreprocessorVariable>var.publishDir</PreprocessorVariable>-->
 				<Transforms>$(ProjectDir)$DxmModuleName$.xslt</Transforms>
 				<SuppressRegistry>true</SuppressRegistry>
@@ -69,7 +69,7 @@
 			</HarvestDirectory>
 		</ItemGroup>
 		<ItemGroup>
-			<HarvestDirectory Include="$(SolutionDir)$ServiceName$/bin/$(Configuration)/net10.0/runtimes/win">
+			<HarvestDirectory Include="$(MSBuildProjectDirectory)/../$ServiceName$/bin/$(Configuration)/net10.0/runtimes/win">
 				<SuppressRegistry>true</SuppressRegistry>
 				<SuppressRootDirectory>true</SuppressRootDirectory>
 				<SuppressCom>true</SuppressCom>
@@ -77,7 +77,7 @@
 				<ComponentGroupName>$DxmModuleName$DotNetWinRuntimeComponents</ComponentGroupName>
 				<DirectoryRefId>INSTALLFOLDERRUNTIMESWIN</DirectoryRefId>
 			</HarvestDirectory>
-			<BindPath Include="$(SolutionDir)$ServiceName$/bin/$(Configuration)/net10.0/runtimes/win"/>
+			<BindPath Include="$(MSBuildProjectDirectory)/../$ServiceName$/bin/$(Configuration)/net10.0/runtimes/win"/>
 		</ItemGroup>
 	</Target>
 </Project>


### PR DESCRIPTION
This pull request updates the installer project templates to improve path handling and configuration flexibility, making builds more robust and portable. The main changes involve shifting from `$(SolutionDir)` to `$(MSBuildProjectDirectory)` for file paths, and passing the MSBuild project directory as a constant for use in WiX and build scripts.

**Build system and path handling improvements:**

* Updated all file and directory paths in `InstallerProject.wixproj` and `DxmModuleName.wxi` to use `$(MSBuildProjectDirectory)` instead of `$(SolutionDir)`, ensuring correct path resolution regardless of how the build is invoked. [[1]](diffhunk://#diff-a0004a8c50078789e4bdf3a7516fa7ff6668bfefc06289deb2ea3de503106c84L52-R60) [[2]](diffhunk://#diff-a0004a8c50078789e4bdf3a7516fa7ff6668bfefc06289deb2ea3de503106c84L72-R80) [[3]](diffhunk://#diff-2785d9cc64dac1809756a9f9680ff5c97c880aa15ff71bc095616c4c20257d4dL7-R7)
* Added `MSBuildProjectDirectory` as a defined constant in both Debug and Release configurations, making it available for WiX preprocessor usage.

**Installer configuration enhancements:**

* Set the `InstallerPlatform` property to `x64` in `InstallerProject.wixproj` to ensure the installer targets 64-bit systems by default.
* Updated the example `dotnet publish` command in the build target to use `$(MSBuildProjectDirectory)` for improved consistency.